### PR TITLE
Skip scan folder if not found instead of error out

### DIFF
--- a/deploy/daemonset.yml
+++ b/deploy/daemonset.yml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: node-cert-exporter
+spec:
+  finalizers:
+  - kubernetes
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-cert-exporter
+  namespace: node-cert-exporter
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: node-cert-exporter
+  name: node-cert-exporter
+  namespace: node-cert-exporter
+spec:
+  selector:
+    matchLabels:
+      app: node-cert-exporter
+  template:
+    metadata:
+      name: node-cert-exporter
+      labels:
+        app: node-cert-exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9117'
+    spec:
+      containers:
+      - image: amimof/node-cert-exporter:latest
+        args:
+        - "--logtostderr=true"
+        - "--path=/host/etc/origin/master/,/host/etc/etcd/"
+        name: node-cert-exporter
+        ports:
+        - containerPort: 9117
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /host/etc
+          name: etc
+          readOnly: true
+      serviceAccount: node-cert-exporter
+      serviceAccountName: node-cert-exporter
+      volumes:
+      - hostPath:
+          path: /etc
+          type: ""
+        name: etc
+  updateStrategy:
+    type: RollingUpdate


### PR DESCRIPTION
If a folder is not found, don't error out and quit. Continue to next folder. This caused container to crash each time a scrape occurred when a path was configured that doesn't exist.