### PR TITLE
Check if code is formatted in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,16 @@ before_install:
 jobs:
   include:
   - stage: test
-    name: "Unit Test"
+    name: "Verify"
     script: 
+    - make checkfmt
     - make fmt
     - make vet 
     - make gocyclo
     - make golint 
     - make ineffassign
     - make misspell
+  - name: "Unit Test"
     - make test
   - name: "Integration Test"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
     - make ineffassign
     - make misspell
   - name: "Unit Test"
+    script:
     - make test
   - name: "Integration Test"
     script:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ PKG_LIST=$$(go list ./... | grep -v /vendor/)
 # Setup the -ldflags option for go build here, interpolate the variable values
 LDFLAGS = -ldflags "-X main.VERSION=${VERSION} -X main.COMMIT=${COMMIT} -X main.BRANCH=${BRANCH} -X main.GOVERSION=${GOVERSION}"
 
+.PHONY: checkfmt
+
 # Build the project
 all: build
 
@@ -22,7 +24,7 @@ dep:
 
 fmt:
 	cd ${BUILD_DIR}; \
-	gofmt -s -d -e -w .; \
+	gofmt -s -e -d -w .; \
 
 vet:
 	cd ${BUILD_DIR}; \
@@ -47,6 +49,13 @@ misspell:
 	go get -u github.com/client9/misspell/cmd/misspell; \
 	cd ${BUILD_DIR}; \
 	find . -type f -not -path "./vendor/*" -not -path "./.git/*" -print0 | xargs -0 ${GOPATH}/bin/misspell; \
+
+checkfmt:
+	cd ${BUILD_DIR}
+	if [ "`gofmt -l .`" != "" ]; then \
+		echo "Code not formatted, please run 'make fmt'"; \
+		exit 1; \
+	fi
 
 ci: fmt vet gocyclo golint ineffassign misspell 
 

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -6,11 +6,11 @@ import (
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 	"io/ioutil"
-	"time"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 var extensions = []string{".pem", ".crt", ".cert", ".cer"}

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -11,7 +11,7 @@ func TestNew(t *testing.T) {
 		t.Fatalf("roots expected to be %d, got %d", 0, len(e.roots))
 	}
 	// Set new root
-	roots := []string{"/etc/ssl","/etc/kubernetes","/etc/origin"}
+	roots := []string{"/etc/ssl", "/etc/kubernetes", "/etc/origin"}
 	e.SetRoots(roots)
 	if len(e.roots) != 3 {
 		t.Fatalf("roots expected to be %d, got %d", len(roots), len(e.roots))


### PR DESCRIPTION
* Added Makefile target `checkfmt` that checks if Go code is formatted using `gofmt -l`. Errors if it is not.