### PR TITLE
Retrieve Nodename from Downward API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ integration-test: docker_build
   	-subj '/CN=localhost/C=SE/L=Gothenburg/O=system:nodes/OU=amimof/ST=Vastra Gotalands Lan' \
   	-keyout ${BUILD_DIR}/out/integration-test/ssl/self-signed-key.pem \
   	-out ${BUILD_DIR}/out/integration-test/ssl/self-signed.pem
-	docker run -d --name node-cert-exporter -v ${BUILD_DIR}/out/integration-test/ssl:/certs -p 9117:9117 amimof/node-cert-exporter:${VERSION} --logtostderr=true --v=4 --path=/certs
+	docker run -d --name node-cert-exporter --hostname 0a9ad966a64e -v ${BUILD_DIR}/out/integration-test/ssl:/certs -p 9117:9117 -e NODE_NAME=docker-node amimof/node-cert-exporter:${VERSION} --logtostderr=true --v=4 --path=/certs
 	sleep 3
 	curl -s http://127.0.0.1:9117/metrics | grep ssl_certificate_expiry_seconds
 	curl -s http://127.0.0.1:9117/metrics | grep 'issuer="CN=localhost,OU=amimof,O=system:nodes,L=Gothenburg,ST=Vastra Gotalands Lan,C=SE"'
@@ -77,6 +77,8 @@ integration-test: docker_build
 	curl -s http://127.0.0.1:9117/metrics | grep 'alg="SHA256-RSA"'
 	curl -s http://127.0.0.1:9117/metrics | grep 'dns_names=""'
 	curl -s http://127.0.0.1:9117/metrics | grep 'email_addresses=""'
+	curl -s http://127.0.0.1:9117/metrics | grep 'hostname="0a9ad966a64e"'
+	curl -s http://127.0.0.1:9117/metrics | grep 'nodename="docker-node"'
 	docker kill node-cert-exporter
 	docker rm node-cert-exporter
 	docker run -d --name node-cert-exporter -v ${BUILD_DIR}/out/integration-test/ssl:/certs -p 9117:9117 amimof/node-cert-exporter:${VERSION} --logtostderr=true --v=4 --path=/certs --exclude-path=/certs

--- a/deploy/daemonset.yml
+++ b/deploy/daemonset.yml
@@ -39,6 +39,11 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--path=/host/etc/origin/node/,/host/etc/origin/master/,/host/etc/etcd/,/host/etc/kubernetes/pki/"
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         name: node-cert-exporter
         ports:
         - containerPort: 9117

--- a/deploy/daemonset.yml
+++ b/deploy/daemonset.yml
@@ -39,11 +39,6 @@ spec:
         - "--v=2"
         - "--logtostderr=true"
         - "--path=/host/etc/origin/node/,/host/etc/origin/master/,/host/etc/etcd/,/host/etc/kubernetes/pki/"
-        env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
         name: node-cert-exporter
         ports:
         - containerPort: 9117

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	extensions  = []string{".pem", ".crt", ".cert", ".cer"}
-	hostname, _ = os.Hostname()
+	nodename = os.Getenv("NODE_NAME")
 )
 
 func findCertPaths(p string, exPaths []string) ([]string, error) {
@@ -82,7 +82,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 // Describe satisfies prometheus.Collector interface
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	ch <- e.certExpiry.WithLabelValues("path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname").Desc()
+	ch <- e.certExpiry.WithLabelValues("path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "nodename").Desc()
 }
 
 // Scrape iterates over the list of file paths (set by SetRoot) and parses any found x509 certificates.
@@ -123,7 +123,7 @@ func (e *Exporter) Scrape(ch chan<- prometheus.Metric) {
 				"subject":         cert.Subject.String(),
 				"dns_names":       strings.Join(cert.DNSNames, ","),
 				"email_addresses": strings.Join(cert.EmailAddresses, ","),
-				"hostname":        hostname,
+				"nodename":        nodename,
 			}
 
 			since := time.Until(cert.NotAfter)
@@ -143,6 +143,6 @@ func New() *Exporter {
 			Name:      "seconds",
 			Help:      "Number of seconds until certificate expires",
 		},
-			[]string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname"}),
+			[]string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "nodename"}),
 	}
 }

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -16,8 +16,9 @@ import (
 )
 
 var (
-	extensions = []string{".pem", ".crt", ".cert", ".cer"}
-	nodename   = os.Getenv("NODE_NAME")
+	extensions  = []string{".pem", ".crt", ".cert", ".cer"}
+	hostname, _ = os.Hostname()
+	nodename    = os.LookupEnv("NODE_NAME")
 )
 
 func findCertPaths(p string, exPaths []string) ([]string, error) {
@@ -82,7 +83,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 // Describe satisfies prometheus.Collector interface
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	ch <- e.certExpiry.WithLabelValues("path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "nodename").Desc()
+	ch <- e.certExpiry.WithLabelValues("path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename").Desc()
 }
 
 // Scrape iterates over the list of file paths (set by SetRoot) and parses any found x509 certificates.
@@ -123,6 +124,7 @@ func (e *Exporter) Scrape(ch chan<- prometheus.Metric) {
 				"subject":         cert.Subject.String(),
 				"dns_names":       strings.Join(cert.DNSNames, ","),
 				"email_addresses": strings.Join(cert.EmailAddresses, ","),
+				"hostname":        hostname,
 				"nodename":        nodename,
 			}
 
@@ -143,6 +145,6 @@ func New() *Exporter {
 			Name:      "seconds",
 			Help:      "Number of seconds until certificate expires",
 		},
-			[]string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "nodename"}),
+			[]string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename"}),
 	}
 }

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	extensions  = []string{".pem", ".crt", ".cert", ".cer"}
-	nodename = os.Getenv("NODE_NAME")
+	extensions = []string{".pem", ".crt", ".cert", ".cer"}
+	nodename   = os.Getenv("NODE_NAME")
 )
 
 func findCertPaths(p string, exPaths []string) ([]string, error) {

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -18,7 +18,7 @@ import (
 var (
 	extensions  = []string{".pem", ".crt", ".cert", ".cer"}
 	hostname, _ = os.Hostname()
-	nodename    = os.LookupEnv("NODE_NAME")
+	nodename    = os.Getenv("NODE_NAME")
 )
 
 func findCertPaths(p string, exPaths []string) ([]string, error) {


### PR DESCRIPTION
This small PR aims to improve the previous [implementation](https://github.com/amimof/node-cert-exporter/pull/25) to add the expected behaviour of retrieving the Nodename from the Downward API and make it available to the running container as an environment variable.

Linking issue #26 