### PR TITLE
Decode first CERTIFICATE block in PEM file

### DIFF
--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -1,8 +1,45 @@
 package exporter
 
 import (
+	"bytes"
+	"encoding/pem"
+	"strings"
 	"testing"
 )
+
+const testCert = `
+-----BEGIN CERTIFICATE-----
+MIICAjCCAWugAwIBAgIUQYz6rBI0tJm0mQwuHVZJQey5sc8wDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIdGVzdC5jb20wHhcNMjAwNTA3MTMzMDI4WhcNMjEwNTA3
+MTMzMDI4WjATMREwDwYDVQQDDAh0ZXN0LmNvbTCBnzANBgkqhkiG9w0BAQEFAAOB
+jQAwgYkCgYEA20I4FBxqE75KODcqagOPZn04qZsj6rFGgCNG34EzCQ3FyZRvdYSy
+5mhLYQPyCOGETRAAaC95h5K1v0sZQISOascpY1syKmkWWRstCmR/B7vfW+vme4z8
+JHKk3jxruOYW+SYtH7G2FpMISuMAs9qxZj1jsPPXhwqwkpq+OLVBH7MCAwEAAaNT
+MFEwHQYDVR0OBBYEFDc1dv0t3hdSPlVo0rDfQ/9Ze8rIMB8GA1UdIwQYMBaAFDc1
+dv0t3hdSPlVo0rDfQ/9Ze8rIMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
+BQADgYEAofnkXC6WYoYisMXJE6XOfxhAbrRTQswWKfo5EW2T3BnjICrplBlG3paq
+U388DQASqCKiadA6QFdkDx5N8JAMbswLK1JrcdgdDx/+zrzIo4Pbm1oM6SXwfhcH
+p1yLjQp67exL1tdjQeOZgFDe55oSygFAkUD1rnKNolUxsMYkPPc=
+-----END CERTIFICATE-----
+`
+const testKey = `
+-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBANtCOBQcahO+Sjg3
+KmoDj2Z9OKmbI+qxRoAjRt+BMwkNxcmUb3WEsuZoS2ED8gjhhE0QAGgveYeStb9L
+GUCEjmrHKWNbMippFlkbLQpkfwe731vr5nuM/CRypN48a7jmFvkmLR+xthaTCErj
+ALPasWY9Y7Dz14cKsJKavji1QR+zAgMBAAECgYBw0b/9SSmkAxQ5nNksN6y/9csE
+Kpnul01Jfd1oABj8naOaN9CqTZ+oQx4WS2ts+m2TIZq0AUmtYuY2CjRyKEMG5kle
+kW0AOAgvN6xrIhE6iaX0xQeZleiJ1Ag0RAHrVqT6CztEq7cXv+1Dhf6kbBY/7MHP
+ySJlQ4g9nPK2KkJ1wQJBAPpEMSLUEDbMnHdiT/4U4CDKhgFI1fpCwFWlKShzZuzd
+KHa6NVwvEyB4ZuWj4dbM0TxVoX8KUtNYY48iyp/YxiMCQQDgSCrdl4bp8Cm+5XGr
+gnVCj5oWjXEepkM1G/IFVQwsVE3h7BtGyVoWxfn68n2rFSb7D0VZPjz2Te0z9gSw
+97ExAkEA+OsadCm4dsjMV3HRXkYlJnhJEL4BFgmOg6DibvlZRf4yYOSUbjvkKkeX
+EJEP7zWIZxpEprb96nffjl5satCRQQJAZ0FSWspUFoe28Gf5uRhKm+Y47oEXvyCU
+eHLxLXtGK3J0mLp2pFQ24Z0rxVi2enk2hQc2yitZLZwaxH1TE5Y1QQJBAI0nFg+C
+8VbocETPOgR8RGeONRRsC9IGR3r1ZaSQhJGaq+isqEryczW2zIaDUbSGrbpZQNBo
+raQ6DbqHFLX6/O8=
+-----END PRIVATE KEY-----
+`
 
 func TestNew(t *testing.T) {
 	e := New()
@@ -29,6 +66,30 @@ func TestIsCertFile(t *testing.T) {
 	for _, cert := range notCerts {
 		if isCertFile(cert) {
 			t.Fatalf("Path %s expected to return false, got true", cert)
+		}
+	}
+}
+
+func TestGetFirstCertBlock(t *testing.T) {
+	tables := []struct {
+		pem    []byte
+		result []byte
+	}{
+		{[]byte(testKey), nil},
+		{[]byte(testCert), []byte(testCert)},
+		{[]byte(strings.Join([]string{testCert, testKey}, "\n")), []byte(testCert)},
+		{[]byte(strings.Join([]string{testKey, testCert}, "\n")), []byte(testCert)},
+		{[]byte(strings.Join([]string{testKey, testCert, testKey}, "\n")), []byte(testCert)},
+		{[]byte(strings.Join([]string{testKey, testKey, testCert}, "\n")), []byte(testCert)},
+	}
+
+	for _, table := range tables {
+		res := getFirstCertBlock(table.pem)
+		expected, _ := pem.Decode(table.result)
+
+		if (table.result == nil && res != nil) ||
+			(table.result != nil && !bytes.Equal(expected.Bytes, res)) {
+			t.Errorf("getFirstCertBlock did not return expected result")
 		}
 	}
 }


### PR DESCRIPTION
<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixed loading of PEM files that don't begin with a CERTIFICATE block, for example ones starting with a key first instead of a certificate.

**- How I did it**
Implemented a function to return the first CERTIFICATE block.

**- How to verify it**
Try to load this file in a current version:
```
-----BEGIN PRIVATE KEY-----
MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC/LZZkQZtfdKAs
uSVhOr/7aPyHmiqQs5dyJEUa+VPRwq7n3nLVoUE7s0AFHDZ5YUtLjJLI2+7kLk1R
8inCtfLDKRa6GbIpqnVJM8gVtuu+/rLKCULsnf40CapqFkQIjoTwoqAdekYwp0xq
dspy9J1B5MUdRyGKqEtlhqGvRP+k7+eLShVTGm4Y+38OKmPIb0S0w7eK59W3TgWH
uOTqTlUA0RzTPa33p7sLRJxS0qyU+QRbzNtwG9ri2dC2uL2e+5K7WfvyR/YPNbwY
DtK7xEm7dhNppR8/HqSD4PoZCMH5rYhCW7z4ImoUN6LE24unPRqali2o+YN4cRFF
U4Zl3hitAgMBAAECggEAcPP9VFTS+O4OKP5nEHBGt8MK2Q+EMKR7SUwWrF49YMS2
1HZAwOmagixhGePWZ5bNhuCSZSxUk+qrckwy0kDwItCnBeNiuW1mCI8Ym4PM+7a+
adJZATZD1/kR/8YSAkA6WXasRV5WFC70Xj67VHokY6dHswmwzpyql1yZMNYCeS7j
4sRTI1ighF3XbPvkRPIyPHIV19ONLmVnxrLs1kCPV0e1jxDAgNNkk4gF0/DG/x4P
DhsSLIU3zW3zG3I4fmuPfY/cyYaC1Kg75b3ucs2Oxw94TFstV503sJVdDcMJZjDv
pzQaFtT9qc0LubPiJ7cjeS82aI1bKaAqZ2GUouylIQKBgQDd19uHBQYNfbbXo0Zs
YBDdZmd2Yfk/FDwYm+7VG8eIEOXyksfLZKVJaxqiyHIbs/jlcw4ha+41rYQ2kXJg
trrjrpM6hFw8netnXgi3fpohEU+miPXe0HztonjW4WRdZoTD/r7+Wg6L2vsINNHu
N1CJlv0Of+T9GfK2ZoSMv+Q/xQKBgQDcnQmj3fBHsC17fhgx35Ua5Ncebkhv8oqx
3FjYN4hlhdGMBBwNXbPYSbdI0W0JEykpxUYnFlgFtDw3qNpOfXpr9pYRIkO7pJ09
qN5PpjTg8luw4+oWqaeR7/OWbUDe0yEBgt17QtA12IihocPrJnZ/tAnjcPX7at4x
kLirD9lbyQKBgBJ/wo2izJtpZUrcEa5N4Hol5PDJQLiS3mQK9MKOm3fsONCejsyW
KvZRWRpD7sgCnPm9O2tsDaQqQQEv5cLM2g7MaviROwPPA2dOPxnWE9I4GFVBzIb1
CcXjK4J3rx/ewal6X8DkD5x3+UD47pyXvj6K+bUw0w6MEGJHcDwwcD8lAoGALbas
pLP8ch5jjk9WnB8EOopouPmJMQlFDA3oqwT20nKkNSs01OAxwAOmYwRiX5sE0I78
NmU+4A+02qO2eMUvdOenuO0ss9ksa/Zt+nsqQeJ2dXUEsKV+/5KFGwqQgpulHzcK
xdvWYRH5XeSzQCq8K0IXOnXRwsMmP4cJfQjPtWECgYEAjvMeyz/qSwuPGlhEtD9r
9kt2orfJg/6yYOni0lpBen13xpT/TwyzDGhZ6qXokz2fFy6TiPx3huEAzV4z8xhD
GZ4O0NPYgiWSG1uYpa92kf+Y15m0IrYaoy6Dq+w8+juu+rr7IEo7ONOdrhh7RSgE
XybgtGE871QZmnnOSE1t9qo=
-----END PRIVATE KEY-----
-----BEGIN CERTIFICATE-----
MIIDrTCCApWgAwIBAgIUZ3f+eAeODr8LvuR5iycy5un6vP8wDQYJKoZIhvcNAQEL
BQAwZjELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEMMAoGA1UECwwDYmxhMREwDwYDVQQD
DAh0ZXN0LmNvbTAeFw0yMDA1MDYxNjUzMTZaFw0yMTA1MDYxNjUzMTZaMGYxCzAJ
BgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5l
dCBXaWRnaXRzIFB0eSBMdGQxDDAKBgNVBAsMA2JsYTERMA8GA1UEAwwIdGVzdC5j
b20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/LZZkQZtfdKAsuSVh
Or/7aPyHmiqQs5dyJEUa+VPRwq7n3nLVoUE7s0AFHDZ5YUtLjJLI2+7kLk1R8inC
tfLDKRa6GbIpqnVJM8gVtuu+/rLKCULsnf40CapqFkQIjoTwoqAdekYwp0xqdspy
9J1B5MUdRyGKqEtlhqGvRP+k7+eLShVTGm4Y+38OKmPIb0S0w7eK59W3TgWHuOTq
TlUA0RzTPa33p7sLRJxS0qyU+QRbzNtwG9ri2dC2uL2e+5K7WfvyR/YPNbwYDtK7
xEm7dhNppR8/HqSD4PoZCMH5rYhCW7z4ImoUN6LE24unPRqali2o+YN4cRFFU4Zl
3hitAgMBAAGjUzBRMB0GA1UdDgQWBBSuR3NILL/BsnSDa2kVBeMMOdvrnjAfBgNV
HSMEGDAWgBSuR3NILL/BsnSDa2kVBeMMOdvrnjAPBgNVHRMBAf8EBTADAQH/MA0G
CSqGSIb3DQEBCwUAA4IBAQBCgeARpdIc5+o+boVzvUwDTMWG2aJ4zAxQJzyBy9iK
L7GL9GfQd8c+2riKON5DPR2rhSG/mvvOoHcQbTafdEs9SIiieo2WSSbal+SP9Moh
9Fq+1Dqqeahs7tpi+fuTAVYor+nraaP0T+xXy5dJAeCOd2Qb8+TovTQy5FuaP/BI
XGCFGmGQU1jUs26Su2te2DMWRpXH0ruHgHWrfJ9r04v0O2Ju157v9D4OjvLJgM02
D56t4TQ8UUs9sZ3IYlMcz6DXt+qdKZUJtrZyyC5ULo5wj9nrrK4bXx3ayxBJYzfI
d7uQJ9BqDmgh1WCEfMU65djjb26OeqnQK5UltlT0kq83
-----END CERTIFICATE-----
```
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
Fixed handling of PEM files that don't start with a CERTIFICATE block.