### PR TITLE
Allow excluding filenames, not just directories

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -27,7 +27,7 @@ func findCertPaths(p string, exPaths []string) ([]string, error) {
 
 		if len(exPaths) > 0 {
 			for _, exPath := range exPaths {
-				if strings.Contains(filepath.Dir(path), exPath) || path == exPath {
+				if strings.Contains(path, exPath) || path == exPath {
 					return nil
 				}
 			}


### PR DESCRIPTION
The proposed change allows to also include filenames from path' of considered certs. This allows to do something like this:

--path=/etc/letsencrypt/live/ --exclude-path=privkey.pem

**- Description for the CHANGELOG**
*  Allow to also include filenames from path