### PR TITLE
expose failed parsing attempts as a metric

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -71,6 +71,7 @@ type Exporter struct {
 	roots      []string
 	exRoots    []string
 	certExpiry *prometheus.GaugeVec
+	certFailed *prometheus.GaugeVec
 }
 
 // SetRoots sets the list of file paths that the exporter should search for certificates in
@@ -111,16 +112,19 @@ func (e *Exporter) Scrape(ch chan<- prometheus.Metric) {
 			data, err := ioutil.ReadFile(path)
 			if err != nil {
 				glog.Warningf("Couldn't read %s: %s", path, err.Error())
+				ch <- e.certFailed.With(prometheus.Labels{"path": path, "nodename": nodename})
 				continue
 			}
 			block := getFirstCertBlock(data)
 			if len(block) == 0 {
 				glog.Warningf("Couldn't find a CERTIFICATE block in %s", path)
+				ch <- e.certFailed.With(prometheus.Labels{"path": path, "nodename": nodename})
 				continue
 			}
 			cert, err := x509.ParseCertificate(block)
 			if err != nil {
 				glog.Warningf("Couldn't parse %s: %s", path, err.Error())
+				ch <- e.certFailed.With(prometheus.Labels{"path": path, "nodename": nodename})
 				continue
 			}
 
@@ -154,5 +158,12 @@ func New() *Exporter {
 			Help:      "Number of seconds until certificate expires",
 		},
 			[]string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename"}),
+		certFailed: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "ssl_certificate",
+			Subsystem: "expiry",
+			Name:      "failed",
+			Help:      "files that were failed to process",
+		},
+			[]string{"path", "nodename"}),
 	}
 }

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -112,19 +112,19 @@ func (e *Exporter) Scrape(ch chan<- prometheus.Metric) {
 			data, err := ioutil.ReadFile(path)
 			if err != nil {
 				glog.Warningf("Couldn't read %s: %s", path, err.Error())
-				ch <- e.certFailed.With(prometheus.Labels{"path": path, "nodename": nodename})
+				ch <- e.certFailed.With(prometheus.Labels{"path": path, "hostname": hostname, "nodename": nodename})
 				continue
 			}
 			block := getFirstCertBlock(data)
 			if len(block) == 0 {
 				glog.Warningf("Couldn't find a CERTIFICATE block in %s", path)
-				ch <- e.certFailed.With(prometheus.Labels{"path": path, "nodename": nodename})
+				ch <- e.certFailed.With(prometheus.Labels{"path": path, "hostname": hostname, "nodename": nodename})
 				continue
 			}
 			cert, err := x509.ParseCertificate(block)
 			if err != nil {
 				glog.Warningf("Couldn't parse %s: %s", path, err.Error())
-				ch <- e.certFailed.With(prometheus.Labels{"path": path, "nodename": nodename})
+				ch <- e.certFailed.With(prometheus.Labels{"path": path, "hostname": hostname, "nodename": nodename})
 				continue
 			}
 
@@ -164,6 +164,6 @@ func New() *Exporter {
 			Name:      "failed",
 			Help:      "files that were failed to process",
 		},
-			[]string{"path", "nodename"}),
+			[]string{"path", "hostname", "nodename"}),
 	}
 }


### PR DESCRIPTION
when a file parsing error occurs, such cases are silently skipped. This patch fixes this behavior. All parsing errors will be exposed as separate metrics indicating the nodename, hostname and full path to the problem file.

**- expose failed parsing attempts**

**- exports dedicated gauge metric with nodename and filepath**

**- put a problem file to the `--path` directory and check output with curl; you should find something like `ssl_certificate_expiry_failed{nodename="",path="/etc/ssl/private/key.pem"} 0` **

**- expose failed parsing attempts as a `ssl_certificate_expiry_failed` metric**