### PR TITLE
Fix premature escape from filesystem walk function

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -79,11 +79,9 @@ func (e *Exporter) Scrape(ch chan<- prometheus.Metric) {
 		exPaths := e.exRoots
 		paths := []string{}
 		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-			if len(exPaths) > 0 {
-				for _, exPath := range exPaths {
-					if strings.Contains(filepath.Dir(path), exPath) || path == exPath {
-						return nil
-					}
+			for _, exPath := range exPaths {
+				if strings.Contains(filepath.Dir(path), exPath) || path == exPath {
+					return nil
 				}
 			}
 


### PR DESCRIPTION
Signed-off-by: Rastislav Barlik <barlik@gmx.com>

<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes #44 by not returning immediately on errors in `lstat()` during file-system walking. Errors in `lstat` might be caused by wrong SELinux context on the files set.

**- How I did it**
When an error occurs, walk function doesn't return immediately, instead a metric is exposed and walking is continued.

**- How to verify it**
Follow the instruction from #44 to reproduce the bug, which is then fixed by applying this change.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
Handle files with incorrect SELinux context