### PR TITLE
Add flags `--include-glob` and `--exclude-glob`

### DIFF
--- a/cmd/node-cert-exporter/main.go
+++ b/cmd/node-cert-exporter/main.go
@@ -31,6 +31,8 @@ var (
 	listen       string
 	paths        []string
 	excludePaths []string
+	includeGlobs []string
+	excludeGlobs []string
 )
 
 func init() {
@@ -38,6 +40,8 @@ func init() {
 	pflag.StringVar(&listen, "listen", ":9117", "Address to listen on for metrics and telemetry. Defaults to :9117")
 	pflag.StringSliceVar(&paths, "path", []string{"."}, "List of paths to search for SSL certificates. Defaults to current directory.")
 	pflag.StringSliceVar(&excludePaths, "exclude-path", []string{}, "List of paths to exclute from searching for SSL certificates.")
+	pflag.StringSliceVar(&includeGlobs, "include-glob", []string{}, "List files matching a pattern to include. This flag can be used multple times.")
+	pflag.StringSliceVar(&excludeGlobs, "exclude-glob", []string{}, "List files matching a pattern to exclude. This flag can be used multple times.")
 }
 
 func main() {
@@ -58,6 +62,9 @@ func main() {
 	e := exporter.New()
 	e.SetRoots(paths)
 	e.SetExcludeRoots(excludePaths)
+	e.IncludeGlobs(includeGlobs)
+	e.ExcludeGlobs(excludeGlobs)
+
 	prometheus.MustRegister(e)
 
 	glog.V(2).Infof("Listening on %s", listen)


### PR DESCRIPTION
<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Allow for passing in file globs that the exporter can use to search for files on the fs

**- How I did it**
Added two new cmd flags `--include-glob` and `--exclude-glob`. They are of type `[]string` which means that they can be used multiple times on the cmd line.

**- How to verify it**
N/A

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
New cmd flags `--include-glob` and `--exclude-glob` 