### PR TITLE
Removes `CR_RELEASE_NAME_TEMPLATE` from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,6 @@ jobs:
       uses: helm/chart-releaser-action@v1.2.0
       env:
         CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        CR_RELEASE_NAME_TEMPLATE: "v{{ .Version }}"
         
   releases:
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**