### PR TITLE
✨ Add tls support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.3-alpine AS build-env
+FROM golang:1.16.13-alpine AS build-env
 RUN  apk add --no-cache git make ca-certificates
 LABEL maintaner="@amimof (github.com/amimof)"
 COPY . /go/src/github.com/amimof/node-cert-exporter

--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,4 @@ require (
 	golang.org/x/tools v0.0.0-20190927185200-7b81e57de26d // indirect
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
Fixes #68 .

**- What I did**
Added TLS support.

**- How I did it**
By adding three new flags (`--tls`, `--tls-cert-file` and `--tls-key-file`).

**- How to verify it**
Generate a server certificate and key:
```bash
openssl genrsa -out server.key 2048
openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
# Fill in some information about the cert as prompted.
# For this example I'm using `node-cert-exporter` as Common Name.
```
Run node-cert-exporter and tell it to use the files:
```bash
node-cert-exporter --tls --tls-key-file=server.key --tls-cert-file=server.crt
```
Use `curl` to check that the connection is encrypted and the correct certificate is used.
```bash
curl --verbose --cacert server.crt --resolve node-cert-exporter:9117:127.0.0.1 https://node-cert-exporter:9117/metrics
# --resolve is used to be able to use the common name as address
# --cacert points to the same certificate that node-cert-exporter is using to verify that it is in fact using the correct key file

# Another option is to add the --insecure flag and just check in the output that the details of the cert are correct
curl --verbose --insecure https://localhost:9117/metrics
```


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
Added TLS support.