### PR TITLE
[Feature] Add support for configuring labels emitted in metrics

### DIFF
--- a/cmd/node-cert-exporter/main.go
+++ b/cmd/node-cert-exporter/main.go
@@ -27,16 +27,17 @@ var BRANCH string
 var GOVERSION string
 
 var (
-	host         string
-	port         int
-	listen       string
-	paths        []string
-	excludePaths []string
-	includeGlobs []string
-	excludeGlobs []string
-	tls          bool
-	tlsCertFile  string
-	tlsKeyFile   string
+	host          string
+	port          int
+	listen        string
+	paths         []string
+	excludePaths  []string
+	includeGlobs  []string
+	excludeGlobs  []string
+	includeLabels []string
+	tls           bool
+	tlsCertFile   string
+	tlsKeyFile    string
 )
 
 func init() {
@@ -46,6 +47,7 @@ func init() {
 	pflag.StringSliceVar(&excludePaths, "exclude-path", []string{}, "List of paths to exclute from searching for SSL certificates.")
 	pflag.StringSliceVar(&includeGlobs, "include-glob", []string{}, "List files matching a pattern to include. This flag can be used multiple times.")
 	pflag.StringSliceVar(&excludeGlobs, "exclude-glob", []string{}, "List files matching a pattern to exclude. This flag can be used multiple times.")
+	pflag.StringSliceVar(&includeLabels, "include-labels", []string{}, "List of labels to include in emitted metrics. This flag can be used multiple times. Default is all labels.")
 	pflag.BoolVar(&tls, "tls", false, "Enable TLS for node-cert-exporter. Defaults to false.")
 	pflag.StringVar(&tlsCertFile, "tls-cert-file", "", "Path to a TLS certificate to use when serving. Required for TLS.")
 	pflag.StringVar(&tlsKeyFile, "tls-key-file", "", "Path to a TLS private key to use when serving. Required for TLS.")
@@ -66,7 +68,7 @@ func main() {
 		return
 	}
 
-	e := exporter.New()
+	e := exporter.New(includeLabels...)
 	e.SetRoots(paths)
 	e.SetExcludeRoots(excludePaths)
 	e.IncludeGlobs(includeGlobs)

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"bytes"
 	"encoding/pem"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -91,5 +92,25 @@ func TestGetFirstCertBlock(t *testing.T) {
 			(table.result != nil && !bytes.Equal(expected.Bytes, res)) {
 			t.Errorf("getFirstCertBlock did not return expected result")
 		}
+	}
+}
+
+func TestNewExporterWithIncludeLabels(t *testing.T) {
+	e := New("alg", "path")
+	w := []string{"alg", "path"}
+	if !reflect.DeepEqual(e.includeLabels, w) {
+		t.Errorf("configuring prometheus labels in New() did not return successfully")
+		t.Errorf("Have: %v", e.includeLabels)
+		t.Errorf("Want: %v", w)
+	}
+}
+
+func TestNewExporterWithDefaultLabels(t *testing.T) {
+	e := New()
+	w := []string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename"}
+	if !reflect.DeepEqual(e.includeLabels, w) {
+		t.Errorf("default prometheus labels in New() did not return successfully")
+		t.Errorf("Have: %v", e.includeLabels)
+		t.Errorf("Want: %v", w)
 	}
 }


### PR DESCRIPTION
In environments with lots of nodes or lots of certificates (or both), emitting all labels might prove problematic due to the increased cardinality.

To keep cardinality under control, this commit introduces a way to configure which labels should be emitted, by introducing a new command line switch, `--include-labels`.

Examples:
```
$ ./bin/node-cert-exporter ... --include-labels alg,path,subject

$ ./bin/node-cert-exporter ... --include-labels alg --include-labels path
```
**- What I did**
Introduced a new switch that allows for choosing which labels emitted metrics should have.

**- How I did it**
New switch, conditionals in exporter.go

**- How to verify it**
- tests are included to ensure filtering inside exporter's New() works
- manually with and without using the `--include-labels` switch, which should show the presence of absence of labels.

**- Description for the CHANGELOG**
Configurable labels in metrics are now possible