### PR TITLE
Add a new label: serial

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -87,7 +87,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 // Describe satisfies prometheus.Collector interface
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	ch <- e.certExpiry.WithLabelValues("path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename").Desc()
+	ch <- e.certExpiry.WithLabelValues("path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename", "serial").Desc()
 }
 
 // Scrape iterates over the list of file paths (set by SetRoot) and parses any found x509 certificates.
@@ -169,6 +169,7 @@ func (e *Exporter) Scrape(ch chan<- prometheus.Metric) {
 			"email_addresses": strings.Join(cert.EmailAddresses, ","),
 			"hostname":        hostname,
 			"nodename":        nodename,
+			"serial":          cert.SerialNumber.String(),
 		}
 
 		since := time.Until(cert.NotAfter)
@@ -187,7 +188,7 @@ func New() *Exporter {
 			Name:      "seconds",
 			Help:      "Number of seconds until certificate expires",
 		},
-			[]string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename"}),
+			[]string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename", "serial"}),
 		certFailed: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "ssl_certificate",
 			Subsystem: "expiry",


### PR DESCRIPTION
Subject, filename or issuer might remain the same across certificate issuances, say, in renewals.

Serial on the other hand, is an attribute that has quite better chances of changing every time a certificate changes.

So, let's expose it as a label to make in-place renewals a detectable event.

Fixes #71 

**- What I did**
- Exposed serial as another label
 
**- How I did it**
- Registered the new label
- Used the value of x509.Certificate's SerialNumber to populate label's value

**- How to verify it**
- curl'ing /metrics will now contain serial as a label and a large number as its label's value.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
We now emit each certificate's serial number as a label