### PR TITLE
Add multi-platform support to Docker build workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,6 +76,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@326560df218a7ea9cf6ab49bbc88b8b306bb437e
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6d5347c4025fdf2bb05167a2519cac535a14a408
+
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,9 +90,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@fdf7f43ecf7c1a5c7afe936410233728a8c2d9c2
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes #86 .

**- What I did**
Updated release.yml workflow to build multi-platform Docker images (currently `linux/amd64` and `linux/arm64`).

**- How I did it**
Following this guide: https://docs.docker.com/build/ci/github-actions/multi-platform/

**- How to verify it**
See tag `v1.1.4-arm2` on my fork - Docker image is here: https://github.com/DeltaWhy/node-cert-exporter/pkgs/container/node-cert-exporter/145642005?tag=v1.1.4-arm2

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**
Add arm64 Docker build workflow