### PR TITLE
Add relative certificate lifetime metric for percentage-based alertin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,41 @@ Once the the node-cert-exporter is scraped by Prometheus, the metrics can easily
 
 ![](./img/grafana.png)
 
+# Metrics
+
+`node-cert-exporter` exports the following metrics:
+
+## `ssl_certificate_expiry_seconds`
+Absolute time in seconds until the certificate expires. This metric is useful for tracking when a certificate will expire.
+
+**Example Prometheus alert rule:**
+```yaml
+- alert: CertificateExpiresIn7Days
+  expr: ssl_certificate_expiry_seconds < (7 * 24 * 3600)
+  annotations:
+    summary: "Certificate {{ $labels.path }} expires in less than 7 days"
+```
+
+## `ssl_certificate_expiry_ratio`
+Relative ratio of remaining certificate lifetime to total validity period. This metric ranges from:
+- **1.0**: Certificate was just issued (100% of lifetime remaining)
+- **0.5**: 50% of certificate lifetime remaining
+- **0.0**: Certificate has expired
+
+This metric is particularly useful for triggering alerts based on relative timeranges, such as when 50% of the certificate lifetime has been consumed.
+
+**Example Prometheus alert rule:**
+```yaml
+- alert: Certificate50PercentLifetimeReached
+  expr: ssl_certificate_expiry_ratio < 0.5
+  annotations:
+    summary: "Certificate {{ $labels.path }} has less than 50% of its lifetime remaining"
+
+- alert: Certificate80PercentConsumed
+  expr: ssl_certificate_expiry_ratio < 0.2
+  annotations:
+    summary: "Certificate {{ $labels.path }} has consumed 80% of its lifetime (20% remaining)"
+```
+
 # Contribute
 All help in any form is highly appreciated and your are welcome participate in developing together. To contribute submit a Pull Request. If you want to provide feedback, open up a Github Issue or contact me personally.

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -57,6 +57,7 @@ type Exporter struct {
 	roots        []string
 	exRoots      []string
 	certExpiry   *prometheus.GaugeVec
+	certExpRatio *prometheus.GaugeVec
 	certFailed   *prometheus.GaugeVec
 }
 
@@ -90,6 +91,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 // Describe satisfies prometheus.Collector interface
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- e.certExpiry.WithLabelValues("path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename", "serial").Desc()
+	ch <- e.certExpRatio.WithLabelValues("path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename", "serial").Desc()
 }
 
 // Scrape iterates over the list of file paths (set by SetRoot) and parses any found x509 certificates.
@@ -175,6 +177,24 @@ func (e *Exporter) Scrape(ch chan<- prometheus.Metric) {
 		since := time.Until(cert.NotAfter)
 		e.certExpiry.With(labels).Set(since.Seconds())
 		ch <- e.certExpiry.With(labels)
+
+		// Calculate and export relative expiry ratio
+		// Ratio = time_remaining / total_validity_period
+		// 1.0 = just issued, 0.5 = 50% of lifetime remaining, 0.0 = expired
+		totalValidity := cert.NotAfter.Sub(cert.NotBefore).Seconds()
+		timeRemaining := time.Until(cert.NotAfter).Seconds()
+		ratio := 0.0
+		if totalValidity > 0 {
+			ratio = timeRemaining / totalValidity
+			// Clamp ratio to [0, 1] range to handle edge cases
+			if ratio < 0 {
+				ratio = 0
+			} else if ratio > 1 {
+				ratio = 1
+			}
+		}
+		e.certExpRatio.With(labels).Set(ratio)
+		ch <- e.certExpRatio.With(labels)
 	}
 
 }
@@ -187,6 +207,13 @@ func New() *Exporter {
 			Subsystem: "expiry",
 			Name:      "seconds",
 			Help:      "Number of seconds until certificate expires",
+		},
+			[]string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename", "serial"}),
+		certExpRatio: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "ssl_certificate",
+			Subsystem: "expiry",
+			Name:      "ratio",
+			Help:      "Ratio of remaining certificate lifetime to total validity period (1.0 = just issued, 0.5 = 50% remaining, 0.0 = expired)",
 		},
 			[]string{"path", "issuer", "alg", "version", "subject", "dns_names", "email_addresses", "hostname", "nodename", "serial"}),
 		certFailed: prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/pem"
 	"strings"
 	"testing"
+	"time"
 )
 
 const testCert = `
@@ -91,5 +92,95 @@ func TestGetFirstCertBlock(t *testing.T) {
 			(table.result != nil && !bytes.Equal(expected.Bytes, res)) {
 			t.Errorf("getFirstCertBlock did not return expected result")
 		}
+	}
+}
+
+func TestExporterMetrics(t *testing.T) {
+	e := New()
+
+	// Verify that both metrics are initialized
+	if e.certExpiry == nil {
+		t.Fatal("certExpiry metric should be initialized")
+	}
+	if e.certExpRatio == nil {
+		t.Fatal("certExpRatio metric should be initialized")
+	}
+}
+
+func TestCertificateRatioCalculation(t *testing.T) {
+	// Test various ratio scenarios
+	tests := []struct {
+		name             string
+		notBefore        string
+		notAfter         string
+		currentTime      string
+		expectedRatioMin float64
+		expectedRatioMax float64
+	}{
+		{
+			name:             "Just issued certificate (should be close to 1.0)",
+			notBefore:        "2024-01-01T00:00:00Z",
+			notAfter:         "2025-01-01T00:00:00Z",
+			currentTime:      "2024-01-01T00:00:01Z",
+			expectedRatioMin: 0.99,
+			expectedRatioMax: 1.0,
+		},
+		{
+			name:             "50% of lifetime remaining",
+			notBefore:        "2024-01-01T00:00:00Z",
+			notAfter:         "2025-01-01T00:00:00Z",
+			currentTime:      "2024-07-02T12:00:00Z",
+			expectedRatioMin: 0.49,
+			expectedRatioMax: 0.51,
+		},
+		{
+			name:             "Near expiry (10% remaining)",
+			notBefore:        "2024-01-01T00:00:00Z",
+			notAfter:         "2025-01-01T00:00:00Z",
+			currentTime:      "2024-11-22T12:00:00Z",
+			expectedRatioMin: 0.09,
+			expectedRatioMax: 0.11,
+		},
+		{
+			name:             "Expired certificate (should be 0.0)",
+			notBefore:        "2024-01-01T00:00:00Z",
+			notAfter:         "2025-01-01T00:00:00Z",
+			currentTime:      "2025-01-02T00:00:00Z",
+			expectedRatioMin: 0.0,
+			expectedRatioMax: 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This test validates the ratio calculation logic conceptually
+			// In actual implementation, the ratio is calculated in the Scrape method
+			// The formula is: ratio = time_remaining / total_validity_period
+
+			// Parse test times
+			notBefore, _ := time.Parse(time.RFC3339, tt.notBefore)
+			notAfter, _ := time.Parse(time.RFC3339, tt.notAfter)
+			currentTime, _ := time.Parse(time.RFC3339, tt.currentTime)
+
+			// Calculate ratio using the same logic as in exporter.go
+			totalValidity := notAfter.Sub(notBefore).Seconds()
+			timeRemaining := notAfter.Sub(currentTime).Seconds()
+			ratio := 0.0
+			if totalValidity > 0 {
+				ratio = timeRemaining / totalValidity
+				// Clamp ratio to [0, 1] range
+				if ratio < 0 {
+					ratio = 0
+				} else if ratio > 1 {
+					ratio = 1
+				}
+			}
+
+			// Verify the ratio is within expected range
+			if ratio < tt.expectedRatioMin || ratio > tt.expectedRatioMax {
+				t.Errorf("Ratio %f is outside expected range [%f, %f]",
+					ratio, tt.expectedRatioMin, tt.expectedRatioMax)
+			}
+		})
 	}
 }


### PR DESCRIPTION
…g (#1)

* Initial plan

* Add relative certificate expiry ratio metric



* Fix alert naming for clarity in documentation



---------

<!--
** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "Fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the CHANGELOG:
-->
**- Description for the CHANGELOG**